### PR TITLE
fix: bugs in recently merged upstream PRs

### DIFF
--- a/custom_components/alexa_media/const.py
+++ b/custom_components/alexa_media/const.py
@@ -128,7 +128,7 @@ an issue here: {ISSUE_URL}
 Domain: {DOMAIN}
 Version: {version}
 API Library: alexapy
-Version: {alexapy_version}
+alexapy Version: {alexapy_version}
 --------------------------------------------------------------------
 """
 

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -819,15 +819,18 @@ class AlexaMediaNotificationSensor(SensorEntity):
 
             # Some consumers expect a single string label for the "next" item.
             # These keys are used by card-alexa-alarms-timers.
+            # Note: Timer and Reminder subclasses set their own label attributes
+            # in extra_state_attributes, so we only set "alarm" here for AlarmSensor.
             if legacy_active:
                 first = legacy_active[0]
-                label_key = self._LABEL_KEY_MAP.get(self._type)
-                if label_key:
-                    attr[self._type.lower()] = first.get(label_key)
-
-                    if self._type == "Reminder":
-                        # Secondary reminder label (when present)
-                        attr["reminder_sub_label"] = first.get("reminderSubLabel")
+                if self._type == "Alarm":
+                    label_key = self._LABEL_KEY_MAP.get(self._type)
+                    if label_key:
+                        attr[self._type.lower()] = first.get(label_key)
+                elif self._type == "Reminder":
+                    # Secondary reminder label (when present)
+                    # Note: main "reminder" label is set by ReminderSensor
+                    attr["reminder_sub_label"] = first.get("reminderSubLabel")
         return attr
 
 


### PR DESCRIPTION
- STARTUP_MESSAGE: Fix confusing double "Version:" format by renaming second "Version:" to "alexapy Version:" for clarity. Keeps "API Library: alexapy" line to identify the library name.

- sensor.py: Remove redundant attribute setting in base class. The base class now only sets "alarm" label for AlarmSensor (which has no extra_state_attributes override). TimerSensor and ReminderSensor set their own "timer"/"reminder" labels, so base class no longer duplicates these. Keeps "reminder_sub_label" in base class as it's only set there.

This fixes code redundancy from PR #3257 where both base class and subclasses would set the same attribute values.