### PR TITLE
fix: Review and merge upstream commits selectively

### DIFF
--- a/custom_components/alexa_media/const.py
+++ b/custom_components/alexa_media/const.py
@@ -114,6 +114,51 @@ ATTR_MESSAGE = "message"
 ATTR_EMAIL = "email"
 ATTR_ENTITY_ID = "entity_id"
 ATTR_NUM_ENTRIES = "entries"
+COMMON_BUCKET_COUNTS = (
+    "accounts",
+    "devices",
+    "media_players",
+    "players",
+    "notifications",
+    "entities",
+)
+COMMON_DIAGNOSTIC_BUCKETS = (
+    "account",
+    "accounts",
+    "login",
+    "logins",
+    "session",
+    "sessions",
+)
+COMMON_DIAGNOSTIC_NAMES = (
+    "name",
+    "deviceName",
+    "accountName",
+    "friendlyName",
+    "title",
+)
+DEVICE_PLAYER_BUCKETS = ("devices", "media_players", "players")
+TO_REDACT: set[str] = {
+    "email",
+    "password",
+    "access_token",
+    "refresh_token",
+    "token",
+    "csrf",
+    "cookie",
+    "cookies",
+    "session",
+    "sessionid",
+    "macDms",
+    "mac_dms",
+    "otp_secret",
+    "authorization_code",
+    "securitycode",
+    "code_verifier",
+    "adp_token",
+    "device_private_key",
+    "customerId",
+}
 STREAMING_ERROR_MESSAGE = (
     "Sorry, direct music streaming isn't supported. "
     "This limitation is set by Amazon, and not by Alexa-Media-Player, Music-Assistant, nor Home-Assistant."
@@ -122,14 +167,10 @@ PUBLIC_URL_ERROR_MESSAGE = (
     "To send TTS, please set the public URL in integration configuration."
 )
 STARTUP_MESSAGE = """
------------------------ {name} -------------------------
-If you have any issues with this custom component, you need to open
-an issue here: {ISSUE_URL}
-Domain: {DOMAIN}
-Version: {version}
-API Library: alexapy
-alexapy Version: {alexapy_version}
---------------------------------------------------------------------
+{name} Version Info
+{DOMAIN}: v{version}
+alexapy API: v{alexapy_version}
+If you have any issues with this custom component, you need to open an issue here: {ISSUE_URL}
 """
 
 AUTH_CALLBACK_PATH = "/auth/alexamedia/callback"

--- a/custom_components/alexa_media/diagnostics.py
+++ b/custom_components/alexa_media/diagnostics.py
@@ -1,0 +1,436 @@
+"""Diagnostics support for Alexa Media Player."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import fields, is_dataclass
+from datetime import datetime
+from itertools import islice
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.redact import async_redact_data
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import (
+    COMMON_BUCKET_COUNTS,
+    COMMON_DIAGNOSTIC_BUCKETS,
+    COMMON_DIAGNOSTIC_NAMES,
+    DEVICE_PLAYER_BUCKETS,
+    DOMAIN,
+    TO_REDACT,
+)
+
+
+# Lazy imports with fallback for alexapy functions
+def _get_hide_email():
+    """Get hide_email function with fallback."""
+    try:
+        from alexapy import hide_email  # pylint: disable=import-outside-toplevel
+
+        return hide_email
+    except (ImportError, AttributeError):
+        return lambda x: "****@****.***"
+
+
+def _get_hide_serial():
+    """Get hide_serial function with fallback."""
+    try:
+        from alexapy import hide_serial  # pylint: disable=import-outside-toplevel
+
+        return hide_serial
+    except (ImportError, AttributeError):
+        return lambda x: "****" if x else None
+
+
+# --------------------
+# Local Functions
+# --------------------
+def _safe_dt(val: Any) -> str | None:
+    """Serialize datetimes safely for JSON diagnostics."""
+    if isinstance(val, datetime):
+        return val.isoformat()
+    return None
+
+
+def _maybe_len(val: Any) -> int | None:
+    """Return length of collection or None if not a collection."""
+    if isinstance(val, (list, tuple, dict, set)):
+        return len(val)
+    return None
+
+
+def _maybe_keys(val: Any, limit: int = 50) -> list[str] | None:
+    """Extract and obfuscate mapping keys, limited to sample size."""
+    if isinstance(val, Mapping):
+        try:
+            # Sample up to `limit` keys to keep diagnostics small.
+            def _safe_key(k: Any) -> str:
+                s = str(k)
+                # Emails/titles/tokens sometimes appear as keys in AMP structures.
+                if re.match(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", s):
+                    try:
+                        hide_email = _get_hide_email()
+                        return hide_email(s)
+                    except (TypeError, ValueError):
+                        pass  # Fall through to obfuscate
+                return _obfuscate_identifier(s)
+
+            return sorted(_safe_key(k) for k in islice(val.keys(), limit))
+        except (TypeError, AttributeError):
+            return None
+    return None
+
+
+def _sample_names(val: Any, *, limit: int = 5) -> list[str] | None:
+    """Try to sample human-friendly names from a list/dict of device-like objects."""
+    names: list[str] = []
+
+    def add_name(x: Any) -> None:
+        if isinstance(x, Mapping):
+            for key in COMMON_DIAGNOSTIC_NAMES:
+                v = x.get(key)
+                if isinstance(v, str) and v:
+                    names.append(v)
+                    return
+        v = getattr(x, "name", None)
+        if isinstance(v, str) and v:
+            names.append(v)
+
+    if isinstance(val, Mapping):
+        for v in islice(val.values(), limit * 2):
+            add_name(v)
+            if len(names) >= limit:
+                break
+        return names[:limit] if names else None
+
+    if isinstance(val, (list, tuple)):
+        for v in val[: limit * 2]:
+            add_name(v)
+            if len(names) >= limit:
+                break
+        return names[:limit] if names else None
+
+    return None
+
+
+# --------------------
+# Coordinator discovery + summary
+# --------------------
+def _find_coordinators(obj: Any) -> list[DataUpdateCoordinator]:
+    """Recursively find DataUpdateCoordinator instances in an object tree."""
+    found: list[DataUpdateCoordinator] = []
+    visited: set[int] = set()
+
+    def walk(x: Any) -> None:
+        obj_id = id(x)
+        if obj_id in visited:
+            return
+        visited.add(obj_id)
+
+        if isinstance(x, DataUpdateCoordinator):
+            found.append(x)
+            return
+        if is_dataclass(x):
+            try:
+                # Walk dataclass attributes directly; asdict() can lose/mangle objects.
+                for f in fields(x):
+                    try:
+                        walk(getattr(x, f.name))
+                    except (AttributeError, TypeError, ValueError):
+                        # Skip fields that can't be read safely
+                        pass
+            except (TypeError, ValueError):
+                # Fallback: vars() can work for some dataclass/slots variations
+                try:
+                    for v in vars(x).values():
+                        walk(v)
+                except (AttributeError, TypeError, ValueError):
+                    pass  # Skip if vars() fails
+            return
+        if isinstance(x, Mapping):
+            for v in x.values():
+                walk(v)
+            return
+        if isinstance(x, (list, tuple, set)):
+            for v in x:
+                walk(v)
+            return
+        # Ignore everything else.
+
+    walk(obj)
+    return found
+
+
+def _summarize_coordinator_data(cdata: Any) -> dict:
+    """
+    Allowlisted summary of coordinator.data.
+
+    Never dump raw coordinator data. Only return counts + small samples.
+    Optimized for AMP: coordinator.data is often a mapping keyed by UUIDs.
+    """
+    out: dict[str, Any] = {}
+
+    if isinstance(cdata, Mapping):
+        out["data_key_count"] = len(cdata)
+
+        key_sample = list(islice(cdata.keys(), 10))
+
+        out["data_key_types_sample"] = [type(k).__name__ for k in key_sample]
+
+        sample_vals = [type(cdata.get(k)).__name__ for k in key_sample[:3]]
+        if sample_vals:
+            out["data_value_types_sample"] = sample_vals
+
+        # If coordinator.data sometimes contains named buckets (future-proof),
+        # include just counts (but only if those keys actually exist).
+        for key in COMMON_DIAGNOSTIC_BUCKETS:
+            if key in cdata:
+                out[f"{key}_count"] = _maybe_len(cdata.get(key))
+
+        # If AMP ever exposes last_called through coordinator.data, include only safe fields.
+        last_called = cdata.get("last_called")
+        if isinstance(last_called, Mapping):
+            ts = last_called.get("timestamp")
+            out["last_called"] = {
+                "timestamp": _safe_dt(ts) or ts,
+                "summary": last_called.get("summary"),
+            }
+
+        # If there are device/player buckets, sample friendly names (no IDs).
+        for key in DEVICE_PLAYER_BUCKETS:
+            if key in cdata:
+                sample = _sample_names(cdata.get(key))
+                if sample:
+                    out[f"{key}_sample_names"] = sample
+                break
+
+        return out
+
+    if isinstance(cdata, (list, tuple)):
+        out["data_len"] = len(cdata)
+        sample = _sample_names(cdata)
+        if sample:
+            out["sample_names"] = sample
+        return out
+
+    if cdata is not None:
+        out["data_type"] = type(cdata).__name__
+    return out
+
+
+def _summarize_coordinator(coordinator: DataUpdateCoordinator) -> dict:
+    """Return a safe, compact view of a coordinator."""
+    exc = getattr(coordinator, "last_exception", None)
+
+    data = {
+        "name": getattr(coordinator, "name", None),
+        "last_update_success": getattr(coordinator, "last_update_success", None),
+        "has_exception": exc is not None,
+        "last_exception_type": type(exc).__name__ if exc else None,
+        "update_interval": (
+            str(getattr(coordinator, "update_interval", None))
+            if getattr(coordinator, "update_interval", None) is not None
+            else None
+        ),
+        "last_update": _safe_dt(getattr(coordinator, "last_update", None)),
+    }
+
+    try:
+        data["data_summary"] = _summarize_coordinator_data(
+            getattr(coordinator, "data", None)
+        )
+    except Exception as exc:  # noqa: BLE001 - intentionally broad; diagnostics must not crash
+        data["data_summary_error"] = type(exc).__name__
+        data["data_summary_error_present"] = True
+
+    return data
+
+
+# --------------------
+# AMP-specific (non-coordinator) runtime summaries
+# --------------------
+def _summarize_amp_entry_runtime(entry_runtime: Any) -> dict:
+    """
+    Best-effort summary of hass.data[DOMAIN][entry_id] runtime.
+
+    AMP may not store anything here; keep robust.
+    """
+    out: dict[str, Any] = {"present": entry_runtime is not None}
+
+    if isinstance(entry_runtime, Mapping):
+        out["runtime_type"] = "mapping"
+        out["runtime_keys"] = _maybe_keys(entry_runtime)
+        # Common "bucket" counts if they happen to exist.
+        for key in COMMON_BUCKET_COUNTS:
+            if key in entry_runtime:
+                out[f"{key}_count"] = _maybe_len(entry_runtime.get(key))
+        # Small sample of names
+        for key in DEVICE_PLAYER_BUCKETS:
+            if key in entry_runtime:
+                sample = _sample_names(entry_runtime.get(key))
+                if sample:
+                    out[f"{key}_sample_names"] = sample
+                break
+    else:
+        if entry_runtime is not None:
+            out["runtime_type"] = type(entry_runtime).__name__
+
+    return out
+
+
+def _obfuscate_identifier(val: Any) -> str:
+    """Obfuscate an identifier, showing only first and last 2 characters."""
+    if not isinstance(val, str) or not val or len(val) <= 4:
+        return "****"
+    return f"{val[:2]}...{val[-2:]}"
+
+
+def _obfuscate_title_with_email(title: str | None, email: str | None) -> str | None:
+    """Obfuscate email in config entry title using the same mechanism as AMP logs."""
+    if not title or not email:
+        return title
+    try:
+        hide_email = _get_hide_email()
+        return title.replace(email, hide_email(email))
+    except (TypeError, ValueError):
+        return title
+
+
+def _get_safe_config_entry_title(config_entry: ConfigEntry) -> str | None:
+    """Get obfuscated config entry title."""
+    email = config_entry.data.get("email")
+    return _obfuscate_title_with_email(config_entry.title, email)
+
+
+def _summarize_amp_domain(domain_data: Any, config_entry: ConfigEntry) -> dict:
+    """
+    Best-effort summary of hass.data[DOMAIN] for AMP.
+
+    AMP historically stores account/login state in custom structures, not always
+    keyed by entry_id, and often not using DataUpdateCoordinator.
+    """
+    out: dict[str, Any] = {}
+    out["domain_data_present"] = domain_data is not None
+    out["domain_data_type"] = (
+        type(domain_data).__name__ if domain_data is not None else None
+    )
+
+    if not isinstance(domain_data, Mapping):
+        return out
+
+    out["domain_keys"] = _maybe_keys(domain_data)
+
+    # Try a few common/likely buckets without dumping contents.
+    # NOTE: We deliberately avoid copying values; only report counts/types/samples.
+    for key in COMMON_DIAGNOSTIC_BUCKETS:
+        if key in domain_data:
+            val = domain_data.get(key)
+            out[f"{key}_type"] = type(val).__name__
+            out[f"{key}_len"] = _maybe_len(val)
+            sample = _sample_names(val)
+            if sample:
+                out[f"{key}_sample_names"] = sample
+
+    # Try to locate the specific account blob by email/title if present.
+    # The config entry title often contains "email - url". We'll only use it to
+    # match keys; we won't add the email to diagnostics (redaction will remove it).
+    raw_title = config_entry.title or ""
+    email = config_entry.data.get("email")
+    out["entry_title_hint"] = _obfuscate_title_with_email(raw_title, email)
+    # Some integrations store per-entry runtime keyed by entry_id *or* by title/email.
+    # Report whether those keys exist.
+    out["has_entry_id_key"] = config_entry.entry_id in domain_data
+    out["has_title_key"] = raw_title in domain_data if raw_title else False
+
+    return out
+
+
+# --------------------
+# Diagnostics entry points
+# --------------------
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> dict:
+    """Return diagnostics for a config entry."""
+    domain_data = hass.data.get(DOMAIN)
+    safe_title = _get_safe_config_entry_title(config_entry)
+
+    # AMP currently doesn't store runtime under entry_id.
+    # This adds future-proofing for if and when it does.
+    entry_runtime = None
+    if isinstance(domain_data, Mapping):
+        entry_runtime = domain_data.get(config_entry.entry_id)
+
+    # Coordinator discovery:
+    # 1) Try under entry_runtime (best practice)
+    # 2) If none found and domain_data is a mapping, try domain_data as a whole
+    coordinators: list[DataUpdateCoordinator] = []
+    searched: list[str] = []
+
+    if entry_runtime is not None:
+        searched.append("hass.data[DOMAIN][entry_id]")
+        coordinators = _find_coordinators(entry_runtime)
+
+    if not coordinators and isinstance(domain_data, Mapping):
+        searched.append("hass.data[DOMAIN]")
+        coordinators = _find_coordinators(domain_data)
+
+    coordinator_summaries = [_summarize_coordinator(c) for c in coordinators]
+
+    data: dict = {
+        "entry": {
+            "entry_id": config_entry.entry_id,
+            "title": safe_title,
+            "domain": config_entry.domain,
+            "version": config_entry.version,
+            "minor_version": config_entry.minor_version,
+        },
+        # Include config + options; sensitive values are redacted below.
+        "data": dict(config_entry.data),
+        "options": dict(config_entry.options),
+        "account": {
+            "searched_for_coordinators_in": searched,
+            "coordinator_count": len(coordinator_summaries),
+            "coordinators": coordinator_summaries,
+            # AMP-specific summaries (useful when coordinator_count == 0)
+            "amp_entry_runtime_summary": _summarize_amp_entry_runtime(entry_runtime),
+            "amp_domain_summary": _summarize_amp_domain(domain_data, config_entry),
+        },
+    }
+
+    return async_redact_data(data, TO_REDACT)
+
+
+async def async_get_device_diagnostics(
+    _hass: HomeAssistant, config_entry: ConfigEntry, device: dr.DeviceEntry
+) -> dict:
+    """Return diagnostics for a specific device."""
+    safe_title = _get_safe_config_entry_title(config_entry)
+    hide_serial = _get_hide_serial()
+
+    data: dict = {
+        "device": {
+            "id": _obfuscate_identifier(device.id),
+            "name": device.name,
+            "name_by_user": device.name_by_user,
+            "manufacturer": device.manufacturer,
+            "model": device.model,
+            "sw_version": device.sw_version,
+            "serial_number": hide_serial(device.serial_number),
+            "identifiers": sorted(
+                (domain, _obfuscate_identifier(value))
+                for domain, value in device.identifiers
+            ),
+            "via_device_id": _obfuscate_identifier(device.via_device_id),
+        },
+        "config_entry": {
+            "entry_id": config_entry.entry_id,
+            "title": safe_title,
+        },
+    }
+
+    return async_redact_data(data, TO_REDACT)

--- a/custom_components/alexa_media/diagnostics.py
+++ b/custom_components/alexa_media/diagnostics.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import re
 from collections.abc import Mapping
 from dataclasses import fields, is_dataclass
 from datetime import datetime
 from itertools import islice
+import re
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -243,7 +243,9 @@ def _summarize_coordinator(coordinator: DataUpdateCoordinator) -> dict:
         data["data_summary"] = _summarize_coordinator_data(
             getattr(coordinator, "data", None)
         )
-    except Exception as exc:  # noqa: BLE001 - intentionally broad; diagnostics must not crash
+    except (
+        Exception
+    ) as exc:  # noqa: BLE001 - intentionally broad; diagnostics must not crash
         data["data_summary_error"] = type(exc).__name__
         data["data_summary_error_present"] = True
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -527,14 +527,14 @@ yarl = ">=1,<2"
 
 [[package]]
 name = "authlib"
-version = "1.6.5"
+version = "1.6.6"
 description = "The ultimate Python library in building OAuth and OpenID Connect servers and clients."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "authlib-1.6.5-py2.py3-none-any.whl", hash = "sha256:3e0e0507807f842b02175507bdee8957a1d5707fd4afb17c32fb43fee90b6e3a"},
-    {file = "authlib-1.6.5.tar.gz", hash = "sha256:6aaf9c79b7cc96c900f0b284061691c5d4e61221640a948fe690b556a6d6d10b"},
+    {file = "authlib-1.6.6-py2.py3-none-any.whl", hash = "sha256:7d9e9bc535c13974313a87f53e8430eb6ea3d1cf6ae4f6efcd793f2e949143fd"},
+    {file = "authlib-1.6.6.tar.gz", hash = "sha256:45770e8e056d0f283451d9996fbb59b70d45722b45d854d58f32878d0a40c38e"},
 ]
 
 [package.dependencies]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,6 +1,7 @@
 """Tests for sensor module."""
 
-from unittest.mock import AsyncMock, MagicMock
+import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -140,3 +141,210 @@ class TestTriggerEvent:
         call_args = sensor.hass.bus.fire.call_args
         assert call_args[0][0] == "alexa_media_notification_event"
         assert call_args[1]["event_data"]["event"] == sensor._active[0]
+
+
+class TestUpdateRecurringAlarm:
+    """Test the _update_recurring_alarm method of AlexaMediaNotificationSensor.
+
+    This class tests the fix for a critical bug where alarm.isoweekday was used
+    instead of alarm.isoweekday() - missing the parentheses to actually call the
+    method. Without the parentheses, the condition would compare a method object
+    to integers, which would always be True, causing incorrect alarm scheduling.
+    """
+
+    def test_isoweekday_method_is_called_correctly(self) -> None:
+        """Test that isoweekday() is called as a method, not accessed as attribute.
+
+        This is a regression test for a bug where alarm.isoweekday was used instead
+        of alarm.isoweekday(). Without the parentheses, a method object would be
+        compared to integers in the recurrence set, which would never match,
+        causing the while loop to run indefinitely or produce wrong results.
+
+        The bug would manifest when:
+        - An alarm is set to ON
+        - The alarm has a recurring pattern (e.g., "every Monday")
+        - The current alarm time is in the past
+        - The current alarm day doesn't match the recurrence pattern
+
+        With the bug, the condition `alarm.isoweekday not in recurrence` would
+        always be True (method object never equals an integer), potentially
+        causing infinite loops or incorrect alarm times.
+        """
+        from custom_components.alexa_media.sensor import AlexaMediaNotificationSensor
+
+        # Create a minimal mock for the sensor
+        sensor = object.__new__(AlexaMediaNotificationSensor)
+        sensor._sensor_property = "alarmTime"
+
+        # Create a datetime that is a Wednesday (isoweekday() == 3)
+        # and set it in the past so the while loop condition is met
+        wednesday_in_past = datetime.datetime(2024, 1, 3, 8, 0, 0)  # Wednesday
+        assert wednesday_in_past.isoweekday() == 3  # Verify it's Wednesday
+
+        # Create recurrence that only allows Fridays (isoweekday 5)
+        # This means the alarm should advance to the next Friday
+        recurrence_fridays_only = {5}
+
+        # Create the alarm notification data
+        value = (
+            "alarm_id",
+            {
+                "status": "ON",
+                "alarmTime": wednesday_in_past,
+                "type": "Alarm",
+                "recurringPattern": "XXXX-WXX-5",  # Every Friday
+            },
+        )
+
+        # Mock dt.now() to return a time after the alarm
+        # so the condition `alarm < dt.now()` is True
+        future_time = datetime.datetime(2024, 1, 10, 8, 0, 0)
+
+        with (
+            patch(
+                "custom_components.alexa_media.sensor.dt.now", return_value=future_time
+            ),
+            patch(
+                "custom_components.alexa_media.sensor.RECURRING_PATTERN_ISO_SET",
+                {"XXXX-WXX-5": recurrence_fridays_only},
+            ),
+        ):
+            result = sensor._update_recurring_alarm(value)
+
+        # The alarm should have been advanced from Wednesday (Jan 3)
+        # to Friday (Jan 5) since only Fridays are in the recurrence
+        result_alarm = result[1]["alarmTime"]
+
+        # With the fix: isoweekday() returns 3, which is not in {5},
+        # so days are added until isoweekday() returns 5 (Friday)
+        assert result_alarm.isoweekday() == 5, (
+            f"Alarm should be on Friday (isoweekday 5), "
+            f"but got isoweekday {result_alarm.isoweekday()}"
+        )
+
+        # Verify the alarm moved forward (not backward)
+        assert result_alarm >= wednesday_in_past
+
+    def test_recurring_alarm_advances_to_correct_weekday(self) -> None:
+        """Test that a recurring alarm advances to the correct weekday."""
+        from custom_components.alexa_media.sensor import AlexaMediaNotificationSensor
+
+        sensor = object.__new__(AlexaMediaNotificationSensor)
+        sensor._sensor_property = "alarmTime"
+
+        # Monday January 1, 2024
+        monday = datetime.datetime(2024, 1, 1, 8, 0, 0)
+        assert monday.isoweekday() == 1
+
+        # Recurrence only on weekends (Saturday=6, Sunday=7)
+        weekend_recurrence = {6, 7}
+
+        value = (
+            "alarm_id",
+            {
+                "status": "ON",
+                "alarmTime": monday,
+                "type": "Alarm",
+                "recurringPattern": "XXXX-WE",  # Weekends
+            },
+        )
+
+        future_time = datetime.datetime(2024, 1, 10, 8, 0, 0)
+
+        with (
+            patch(
+                "custom_components.alexa_media.sensor.dt.now", return_value=future_time
+            ),
+            patch(
+                "custom_components.alexa_media.sensor.RECURRING_PATTERN_ISO_SET",
+                {"XXXX-WE": weekend_recurrence},
+            ),
+        ):
+            result = sensor._update_recurring_alarm(value)
+
+        result_alarm = result[1]["alarmTime"]
+
+        # Should advance to Saturday (Jan 6, 2024)
+        assert result_alarm.isoweekday() in {
+            6,
+            7,
+        }, f"Alarm should be on weekend, but got isoweekday {result_alarm.isoweekday()}"
+        assert result_alarm == datetime.datetime(2024, 1, 6, 8, 0, 0)
+
+    def test_alarm_on_correct_day_not_modified(self) -> None:
+        """Test that an alarm already on a correct day is not modified."""
+        from custom_components.alexa_media.sensor import AlexaMediaNotificationSensor
+
+        sensor = object.__new__(AlexaMediaNotificationSensor)
+        sensor._sensor_property = "alarmTime"
+
+        # Friday January 5, 2024
+        friday = datetime.datetime(2024, 1, 5, 8, 0, 0)
+        assert friday.isoweekday() == 5
+
+        # Recurrence includes Friday
+        recurrence_with_friday = {5}
+
+        value = (
+            "alarm_id",
+            {
+                "status": "ON",
+                "alarmTime": friday,
+                "type": "Alarm",
+                "recurringPattern": "XXXX-WXX-5",
+            },
+        )
+
+        # Even with future time, alarm should not advance if it's already on correct day
+        # Note: the loop only runs if alarm < dt.now(), so if alarm is in the past
+        # but on correct day, it won't advance
+        past_time = datetime.datetime(2024, 1, 4, 8, 0, 0)  # Thursday before alarm
+
+        with (
+            patch(
+                "custom_components.alexa_media.sensor.dt.now", return_value=past_time
+            ),
+            patch(
+                "custom_components.alexa_media.sensor.RECURRING_PATTERN_ISO_SET",
+                {"XXXX-WXX-5": recurrence_with_friday},
+            ),
+        ):
+            result = sensor._update_recurring_alarm(value)
+
+        # Alarm should not be modified since it's in the future relative to now
+        assert result[1]["alarmTime"] == friday
+
+    def test_alarm_off_not_advanced(self) -> None:
+        """Test that an alarm with status OFF is not advanced."""
+        from custom_components.alexa_media.sensor import AlexaMediaNotificationSensor
+
+        sensor = object.__new__(AlexaMediaNotificationSensor)
+        sensor._sensor_property = "alarmTime"
+
+        wednesday = datetime.datetime(2024, 1, 3, 8, 0, 0)
+
+        value = (
+            "alarm_id",
+            {
+                "status": "OFF",  # Alarm is OFF
+                "alarmTime": wednesday,
+                "type": "Alarm",
+                "recurringPattern": "XXXX-WXX-5",
+            },
+        )
+
+        future_time = datetime.datetime(2024, 1, 10, 8, 0, 0)
+
+        with (
+            patch(
+                "custom_components.alexa_media.sensor.dt.now", return_value=future_time
+            ),
+            patch(
+                "custom_components.alexa_media.sensor.RECURRING_PATTERN_ISO_SET",
+                {"XXXX-WXX-5": {5}},
+            ),
+        ):
+            result = sensor._update_recurring_alarm(value)
+
+        # Alarm should NOT be advanced since status is OFF
+        assert result[1]["alarmTime"] == wednesday


### PR DESCRIPTION
- Add diagnostics.py module for Home Assistant diagnostics with:
  - Config entry and device-level diagnostics
  - Privacy-safe summarization with redaction utilities
  - Defensive lazy imports for alexapy functions (fixes from PR #3292)
  - Moved re import to top-level for code quality
- Add diagnostic constants to const.py (TO_REDACT, COMMON_BUCKET_COUNTS, etc.)
- Update STARTUP_MESSAGE to more compact format (PR #3290)
- Bump authlib dependency from 1.6.5 to 1.6.6 (PR #3265)
- Add TestUpdateRecurringAlarm tests for isoweekday() fix (PR #3291)
- Add TestAddDevicesFilterDefaults regression tests (PR #3291)

Note: Our bug fixes are preserved and NOT overwritten by upstream changes:
- sensor.py: correct sensors.values() iteration (not sensors[key].values())
- notify.py: correct 'or' logic (not 'and' which causes AttributeError)
- __init__.py: timedelta migration for JSON serialization
- alarm_control_panel.py: safe index access with length check
- config_flow.py: integration reload after successful reauth