### PR TITLE
fix: prevent template "No first item, sequence was empty" error for l…

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -1766,6 +1766,15 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
         coordinator.update_interval = timedelta(
             seconds=scan_interval * 10 if http2_enabled else scan_interval
         )
+    # Fetch last_called BEFORE the coordinator refresh so that the stored
+    # data is already available when media_player entities are first created
+    # inside async_update_data().  Their refresh() → _get_last_called() will
+    # then find the stored serial and set _last_called = True for the correct
+    # device, preventing an empty-sequence error in user templates that filter
+    # on last_called.
+    _LOGGER.debug("%s: setup_alexa: Updating last_called", hide_email(email))
+    await update_last_called(login_obj)
+
     # Fetch initial data so we have data when entities subscribe
     _LOGGER.debug("%s: setup_alexa: Refreshing coordinator", hide_email(email))
     await coordinator.async_refresh()
@@ -1774,9 +1783,6 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
         hass, functions={"update_last_called": update_last_called}
     )
     await alexa_services.register()
-
-    _LOGGER.debug("%s: setup_alexa: Updating last_called", hide_email(email))
-    await update_last_called(login_obj)
 
     return True
 

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -280,7 +280,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
         self._player_info = None
         self._waiting_media_id = None
         # Last Device
-        self._last_called = None
+        self._last_called = False
         self._last_called_timestamp = None
         self._last_called_summary = None
         # Do not Disturb state
@@ -768,15 +768,16 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                 self._connected_bluetooth = self._get_connected_bluetooth()
                 self._bluetooth_list = self._get_bluetooth_list()
             new_last_called = self._get_last_called()
-            if new_last_called and self._last_called != new_last_called:
+            if self._last_called != new_last_called:
                 self._last_called = new_last_called
-                self._last_called_timestamp = self.hass.data[DATA_ALEXAMEDIA][
-                    "accounts"
-                ][self._login.email]["last_called"]["timestamp"]
-                self._last_called_summary = self.hass.data[DATA_ALEXAMEDIA]["accounts"][
-                    self._login.email
-                ]["last_called"].get("summary")
-                await self._update_notify_targets()
+                if new_last_called:
+                    self._last_called_timestamp = self.hass.data[DATA_ALEXAMEDIA][
+                        "accounts"
+                    ][self._login.email]["last_called"]["timestamp"]
+                    self._last_called_summary = self.hass.data[DATA_ALEXAMEDIA][
+                        "accounts"
+                    ][self._login.email]["last_called"].get("summary")
+                    await self._update_notify_targets()
             if skip_api and self.hass:
                 self.schedule_update_ha_state()
                 return


### PR DESCRIPTION
…ast_called

Three root causes made user templates that filter on `last_called` hit an empty-sequence error from Jinja2's `| first` filter:

1. `_last_called` was initialised as `None` instead of `False`.  The attribute is boolean by nature (is this device the last-called one?) so `None` was a spurious third state.

2. `refresh()` only updated `_last_called` when `_get_last_called()` returned `True` (the condition `if new_last_called and …` short- circuited on `False`).  Non-last-called devices therefore kept `_last_called = None` via this path, and a previously last-called device was never reset to `False` on refresh.

3. `update_last_called()` ran AFTER `coordinator.async_refresh()`, which creates and refreshes entities.  When entities called `_get_last_called()` for the first time, no stored data existed yet, so every device returned `False` and no device had `True`.

Fix: initialise `_last_called = False`, always apply the result of `_get_last_called()` in `refresh()`, and call `update_last_called()` before the coordinator refresh so stored data is available when entities are first created.

https://claude.ai/code/session_01Gtf89c6oEWMXLE4veaYkKK